### PR TITLE
Lower MTU to 1200 bytes

### DIFF
--- a/include/udx.h
+++ b/include/udx.h
@@ -5,12 +5,12 @@
 extern "C" {
 #endif
 
-#include <stdint.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <uv.h>
 
 // TODO: research the packets sizes a bit more
-#define UDX_MTU           1400
+#define UDX_MTU           1200
 #define UDX_HEADER_SIZE   20
 #define UDX_MAX_DATA_SIZE (UDX_MTU - UDX_HEADER_SIZE)
 

--- a/src/udx.c
+++ b/src/udx.c
@@ -1166,7 +1166,6 @@ udx_stream_init (udx_t *udx, udx_stream_t *handle, uint32_t local_id, udx_stream
   return 0;
 }
 
-
 int
 udx_stream_get_seq (udx_stream_t *handle, uint32_t *seq) {
   *seq = handle->seq;


### PR DESCRIPTION
This ensures that UDX stays within the MTU of several VPNs, notably Cloudflare WARP which has an IPv4 MTU of 1260 bytes.