### PR TITLE
Make MTU configurable

### DIFF
--- a/binding.c
+++ b/binding.c
@@ -176,7 +176,7 @@ on_udx_stream_read (udx_stream_t *stream, ssize_t read_len, const uv_buf_t *buf)
   n->read_buf_head += buf->len;
   n->read_buf_free -= buf->len;
 
-  if (n->mode == UDX_NAPI_NON_INTERACTIVE && n->read_buf_free >= UDX_MTU) {
+  if (n->mode == UDX_NAPI_NON_INTERACTIVE && n->read_buf_free >= stream->mtu) {
     return;
   }
 
@@ -548,6 +548,17 @@ NAPI_METHOD(udx_napi_stream_init) {
   return NULL;
 }
 
+NAPI_METHOD(udx_napi_stream_set_mtu) {
+  NAPI_ARGV(2)
+  NAPI_ARGV_BUFFER_CAST(udx_stream_t *, stream, 0)
+  NAPI_ARGV_UINT32(mtu, 1)
+
+  int err = udx_stream_set_mtu(stream, mtu);
+  if (err < 0) UDX_NAPI_THROW(err)
+
+  return NULL;
+}
+
 NAPI_METHOD(udx_napi_stream_set_seq) {
   NAPI_ARGV(2)
   NAPI_ARGV_BUFFER_CAST(udx_stream_t *, stream, 0)
@@ -839,6 +850,7 @@ NAPI_INIT() {
   NAPI_EXPORT_FUNCTION(udx_napi_socket_close)
 
   NAPI_EXPORT_FUNCTION(udx_napi_stream_init)
+  NAPI_EXPORT_FUNCTION(udx_napi_stream_set_mtu)
   NAPI_EXPORT_FUNCTION(udx_napi_stream_set_seq)
   NAPI_EXPORT_FUNCTION(udx_napi_stream_set_ack)
   NAPI_EXPORT_FUNCTION(udx_napi_stream_set_mode)

--- a/binding.c
+++ b/binding.c
@@ -176,7 +176,7 @@ on_udx_stream_read (udx_stream_t *stream, ssize_t read_len, const uv_buf_t *buf)
   n->read_buf_head += buf->len;
   n->read_buf_free -= buf->len;
 
-  if (n->mode == UDX_NAPI_NON_INTERACTIVE && n->read_buf_free >= stream->mtu) {
+  if (n->mode == UDX_NAPI_NON_INTERACTIVE && n->read_buf_free >= 2 * UDX_DEFAULT_MTU) {
     return;
   }
 

--- a/include/udx.h
+++ b/include/udx.h
@@ -10,9 +10,9 @@ extern "C" {
 #include <uv.h>
 
 // TODO: research the packets sizes a bit more
-#define UDX_MTU           1200
-#define UDX_HEADER_SIZE   20
-#define UDX_MAX_DATA_SIZE (UDX_MTU - UDX_HEADER_SIZE)
+#define UDX_DEFAULT_MTU        1200
+#define UDX_HEADER_SIZE        20
+#define UDX_MAX_DATA_SIZE(mtu) (mtu - UDX_HEADER_SIZE)
 
 #define UDX_CLOCK_GRANULARITY_MS 20
 
@@ -163,6 +163,8 @@ struct udx_stream {
   udx_stream_recv_cb on_recv;
   udx_stream_drain_cb on_drain;
   udx_stream_close_cb on_close;
+
+  uint16_t mtu;
 
   uint32_t seq;
   uint32_t ack;
@@ -320,6 +322,12 @@ udx_check_timeouts (udx_t *handle);
 
 int
 udx_stream_init (udx_t *udx, udx_stream_t *handle, uint32_t local_id, udx_stream_close_cb close_cb);
+
+int
+udx_stream_get_mtu (udx_stream_t *handle, uint16_t *mtu);
+
+int
+udx_stream_set_mtu (udx_stream_t *handle, uint16_t mtu);
 
 int
 udx_stream_get_seq (udx_stream_t *handle, uint32_t *seq);

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -88,6 +88,11 @@ module.exports = class UDXStream extends streamx.Duplex {
     binding.udx_napi_stream_set_mode(this._handle, bool ? 0 : 1)
   }
 
+  setMTU (mtu) {
+    if (this._closed) return
+    binding.udx_napi_stream_set_mtu(this._handle, mtu)
+  }
+
   connect (socket, remoteId, port, host, opts = {}) {
     if (this._closed) return
 


### PR DESCRIPTION
I haven't yet touched the JavaScript side of things as we need to decide on how the MTU should be configured. Should callers determine it up front, before constructing a stream, and then pass it as an option to `createStream()`? Should callers create a stream with the default MTU and then adapt it as needed?