### PR TITLE
Add test cases for trySend method

### DIFF
--- a/test/socket.js
+++ b/test/socket.js
@@ -218,3 +218,96 @@ test('send after close', async function (t) {
 
   t.is(await a.send(Buffer.from('hello'), a.address().port), false)
 })
+
+test('trySend simple message', async function (t) {
+  t.plan(4)
+
+  const u = new UDX()
+  const a = u.createSocket()
+
+  a.on('message', function (message, { host, family, port }) {
+    t.alike(message, Buffer.from('hello'))
+    t.is(host, '127.0.0.1')
+    t.is(family, 4)
+    t.is(port, a.address().port)
+    a.close()
+  })
+
+  a.bind(0)
+  a.trySend(Buffer.from('hello'), a.address().port)
+})
+
+test('trySend simple message ipv6', async function (t) {
+  t.plan(4)
+
+  const u = new UDX()
+  const a = u.createSocket()
+
+  a.on('message', function (message, { host, family, port }) {
+    t.alike(message, Buffer.from('hello'))
+    t.is(host, '::1')
+    t.is(family, 6)
+    t.is(port, a.address().port)
+    a.close()
+  })
+
+  a.bind(0, '::1')
+  a.trySend(Buffer.from('hello'), a.address().port, '::1')
+})
+
+test('trySend empty message', async function (t) {
+  t.plan(1)
+
+  const u = new UDX()
+  const a = u.createSocket()
+
+  a.on('message', function (message) {
+    t.alike(message, Buffer.alloc(0))
+    a.close()
+  })
+
+  a.bind(0)
+  a.trySend(Buffer.alloc(0), a.address().port)
+})
+
+test('close socket while try sending', async function (t) {
+  t.plan(2)
+
+  const u = new UDX()
+  const a = u.createSocket()
+
+  a.bind()
+
+  a.on('message', function (message) {
+    t.fail('should not receive message')
+  })
+
+  a.on('close', function () {
+    t.pass()
+  })
+
+  t.is(a.trySend(Buffer.from('hello'), a.address().port), undefined)
+
+  a.close()
+})
+
+test('trySend after close', async function (t) {
+  t.plan(2)
+
+  const u = new UDX()
+
+  const a = u.createSocket()
+
+  a.on('message', function (message) {
+    t.fail('should not receive message')
+  })
+
+  a.on('close', function () {
+    t.pass()
+  })
+
+  a.bind(0)
+  a.close()
+
+  t.is(a.trySend(Buffer.from('hello'), a.address().port), undefined)
+})

--- a/test/socket.js
+++ b/test/socket.js
@@ -219,7 +219,7 @@ test('send after close', async function (t) {
   t.is(await a.send(Buffer.from('hello'), a.address().port), false)
 })
 
-test('trySend simple message', async function (t) {
+test('try send simple message', async function (t) {
   t.plan(4)
 
   const u = new UDX()
@@ -237,7 +237,7 @@ test('trySend simple message', async function (t) {
   a.trySend(Buffer.from('hello'), a.address().port)
 })
 
-test('trySend simple message ipv6', async function (t) {
+test('try send simple message ipv6', async function (t) {
   t.plan(4)
 
   const u = new UDX()
@@ -255,7 +255,7 @@ test('trySend simple message ipv6', async function (t) {
   a.trySend(Buffer.from('hello'), a.address().port, '::1')
 })
 
-test('trySend empty message', async function (t) {
+test('try send empty message', async function (t) {
   t.plan(1)
 
   const u = new UDX()
@@ -291,7 +291,7 @@ test('close socket while try sending', async function (t) {
   a.close()
 })
 
-test('trySend after close', async function (t) {
+test('try send after close', async function (t) {
   t.plan(2)
 
   const u = new UDX()

--- a/test/stream.js
+++ b/test/stream.js
@@ -180,7 +180,7 @@ test('unordered messages', async function (t) {
   a.send(Buffer.from('d'))
 })
 
-test('unordered messages using trySend', async function (t) {
+test('try send unordered messages', async function (t) {
   t.plan(2)
 
   const [a, b] = makeTwoStreams(t)

--- a/test/stream.js
+++ b/test/stream.js
@@ -180,6 +180,40 @@ test('unordered messages', async function (t) {
   a.send(Buffer.from('d'))
 })
 
+test('unordered messages using trySend', async function (t) {
+  t.plan(2)
+
+  const [a, b] = makeTwoStreams(t)
+  const expected = []
+
+  b.on('message', function (buf) {
+    b.trySend(Buffer.from('echo: ' + buf.toString()))
+  })
+
+  a.on('error', function () {
+    t.pass('a destroyed')
+  })
+
+  a.on('message', function (buf) {
+    expected.push(buf.toString())
+
+    if (expected.length === 3) {
+      t.alike(expected.sort(), [
+        'echo: a',
+        'echo: bc',
+        'echo: d'
+      ])
+
+      // TODO: .end() here triggers a bug, investigate
+      b.destroy()
+    }
+  })
+
+  a.trySend(Buffer.from('a'))
+  a.trySend(Buffer.from('bc'))
+  a.trySend(Buffer.from('d'))
+})
+
 test('ipv6 streams', async function (t) {
   t.plan(1)
 


### PR DESCRIPTION
Is `trySend()` used internally or required for some reason? It seems interchangeable with `send()` without awaiting. Also that would mean two methods to do the same thing?

Btw, I copied and pasted from the `send()` tests. The ones modifieds are: `close socket while try sending` and `trySend after close`, where the "behaviour" is different. I skipped `echo sockets (250 messages)` for `trySend()`.

Another possibility is to mix both methods tests in the same unit tests so there is no that much repeated test code.