### PR TITLE
Add several tests for sockets

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -140,7 +140,7 @@ module.exports = class UDXSocket extends events.EventEmitter {
 
   async close () {
     if (this._closing) return this._closing
-    this._closing = events.once(this, 'close')
+    this._closing = (this._inited && this.idle) ? events.once(this, 'close') : Promise.resolve(true)
     this._closeMaybe()
     return this._closing
   }

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -179,7 +179,7 @@ module.exports = class UDXSocket extends events.EventEmitter {
     return binding.udx_napi_socket_set_send_buffer_size(this._handle, size)
   }
 
-  async send (buffer, port, host, ttl) {
+  send (buffer, port, host, ttl) {
     if (this.closing) return false
 
     if (!host) host = '127.0.0.1'

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -138,7 +138,7 @@ module.exports = class UDXSocket extends events.EventEmitter {
     this.emit('listening')
   }
 
-  close () {
+  async close () {
     if (this._closing) return this._closing
     this._closing = events.once(this, 'close')
     this._closeMaybe()
@@ -179,7 +179,7 @@ module.exports = class UDXSocket extends events.EventEmitter {
     return binding.udx_napi_socket_set_send_buffer_size(this._handle, size)
   }
 
-  send (buffer, port, host, ttl) {
+  async send (buffer, port, host, ttl) {
     if (this.closing) return false
 
     if (!host) host = '127.0.0.1'

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -138,7 +138,7 @@ module.exports = class UDXSocket extends events.EventEmitter {
     this.emit('listening')
   }
 
-  async close () {
+  close () {
     if (this._closing) return this._closing
     this._closing = events.once(this, 'close')
     this._closeMaybe()

--- a/test/socket.js
+++ b/test/socket.js
@@ -419,7 +419,7 @@ test('try send without bind', async function (t) {
   a.trySend(Buffer.from('hello'), b.address().port)
 })
 
-test('get address without bind', async function (t) {
+test('get address without bind', function (t) {
   const u = new UDX()
   const a = u.createSocket()
   t.is(a.address(), null)

--- a/test/socket.js
+++ b/test/socket.js
@@ -328,6 +328,9 @@ test('connect to invalid host ip', function (t) {
   } catch (error) {
     t.is(error.message, `${invalidHost} is not a valid IP address`)
   }
+
+  s.destroy()
+  a.close()
 })
 
 test('bind to invalid host ip', function (t) {
@@ -343,6 +346,8 @@ test('bind to invalid host ip', function (t) {
   } catch (error) {
     t.is(error.message, `${invalidHost} is not a valid IP address`)
   }
+
+  a.close()
 })
 
 test('send to invalid host ip', async function (t) {

--- a/test/socket.js
+++ b/test/socket.js
@@ -313,7 +313,7 @@ test('try send after close', async function (t) {
   t.is(a.trySend(Buffer.from('hello'), a.address().port), undefined)
 })
 
-test('connect to invalid host ip', async function (t) {
+test('connect to invalid host ip', function (t) {
   t.plan(1)
 
   const u = new UDX()
@@ -330,7 +330,7 @@ test('connect to invalid host ip', async function (t) {
   }
 })
 
-test('bind to invalid host ip', async function (t) {
+test('bind to invalid host ip', function (t) {
   t.plan(1)
 
   const u = new UDX()
@@ -444,7 +444,7 @@ test('bind twice', async function (t) {
   await a.close()
 })
 
-test('bind while closing', async function (t) {
+test('bind while closing', function (t) {
   t.plan(1)
 
   const u = new UDX()
@@ -467,10 +467,12 @@ test('close twice', async function (t) {
 
   a.bind(0)
 
-  const closing1 = a.close()
-  const closing2 = a.close()
+  a.on('close', function () {
+    t.pass()
+  })
 
-  t.ok(closing1 === closing2)
+  a.close()
+  a.close()
 })
 
 test('set TTL', async function (t) {
@@ -531,7 +533,7 @@ test('set recv buffer size', async function (t) {
   a.bind(0)
   a.setRecvBufferSize(NEW_BUFFER_SIZE)
 
-  t.is(a.getRecvBufferSize(), NEW_BUFFER_SIZE)
+  t.ok(a.getRecvBufferSize() >= NEW_BUFFER_SIZE)
 
   await a.close()
 })
@@ -571,24 +573,24 @@ test('set send buffer size', async function (t) {
   a.bind(0)
   a.setSendBufferSize(NEW_BUFFER_SIZE)
 
-  t.is(a.getSendBufferSize(), NEW_BUFFER_SIZE)
+  t.ok(a.getSendBufferSize() >= NEW_BUFFER_SIZE)
 
   await a.close()
 })
 
-test('UDXSocket - isIPv4', async function (t) {
+test('UDXSocket - isIPv4', function (t) {
   t.is(UDXSocket.isIPv4('127.0.0.1'), true)
   t.is(UDXSocket.isIPv4('::1'), false)
   t.is(UDXSocket.isIPv4('0.-1.0.0'), false)
 })
 
-test('UDXSocket - isIPv6', async function (t) {
+test('UDXSocket - isIPv6', function (t) {
   t.is(UDXSocket.isIPv6('127.0.0.1'), false)
   t.is(UDXSocket.isIPv6('::1'), true)
   t.is(UDXSocket.isIPv6('0.-1.0.0'), false)
 })
 
-test('UDXSocket - isIP', async function (t) {
+test('UDXSocket - isIP', function (t) {
   t.is(UDXSocket.isIP('127.0.0.1'), 4)
   t.is(UDXSocket.isIP('::1'), 6)
   t.is(UDXSocket.isIP('0.-1.0.0'), 0)

--- a/test/socket.js
+++ b/test/socket.js
@@ -419,10 +419,11 @@ test('try send without bind', async function (t) {
   a.trySend(Buffer.from('hello'), b.address().port)
 })
 
-test('get address without bind', function (t) {
+test('get address without bind', async function (t) {
   const u = new UDX()
   const a = u.createSocket()
   t.is(a.address(), null)
+  await a.close()
 })
 
 test('bind twice', async function (t) {

--- a/test/socket.js
+++ b/test/socket.js
@@ -325,7 +325,6 @@ test('connect to invalid host ip', async function (t) {
 
   try {
     s.connect(a, 2, 0, invalidHost)
-    t.fail('Should have given error')
   } catch (error) {
     t.is(error.message, `${invalidHost} is not a valid IP address`)
   }

--- a/test/socket.js
+++ b/test/socket.js
@@ -422,7 +422,10 @@ test('try send without bind', async function (t) {
 test('get address without bind', async function (t) {
   const u = new UDX()
   const a = u.createSocket()
+
   t.is(a.address(), null)
+
+  a.close()
 })
 
 test('bind twice', async function (t) {

--- a/test/socket.js
+++ b/test/socket.js
@@ -330,6 +330,149 @@ test('connect to invalid host ip', async function (t) {
   }
 })
 
+test('bind to invalid host ip', async function (t) {
+  t.plan(1)
+
+  const u = new UDX()
+  const a = u.createSocket()
+
+  const invalidHost = '0.-1.0.0'
+
+  try {
+    a.bind(0, invalidHost)
+  } catch (error) {
+    t.is(error.message, `${invalidHost} is not a valid IP address`)
+  }
+})
+
+test('send to invalid host ip', async function (t) {
+  t.plan(1)
+
+  const u = new UDX()
+  const a = u.createSocket()
+
+  a.bind(0)
+
+  const invalidHost = '0.-1.0.0'
+
+  try {
+    await a.send(Buffer.from('hello'), a.address().port, invalidHost)
+  } catch (error) {
+    t.is(error.message, `${invalidHost} is not a valid IP address`)
+  }
+
+  await a.close()
+})
+
+test('try send to invalid host ip', async function (t) {
+  t.plan(1)
+
+  const u = new UDX()
+  const a = u.createSocket()
+
+  a.bind(0)
+
+  const invalidHost = '0.-1.0.0'
+
+  try {
+    a.trySend(Buffer.from('hello'), a.address().port, invalidHost)
+  } catch (error) {
+    t.is(error.message, `${invalidHost} is not a valid IP address`)
+  }
+
+  await a.close()
+})
+
+test('send without bind', async function (t) {
+  t.plan(1)
+
+  const u = new UDX()
+
+  const a = u.createSocket()
+  const b = u.createSocket()
+
+  b.on('message', function (message) {
+    console.log('recv')
+    t.alike(message, Buffer.from('hello'))
+    a.close()
+    b.close()
+  })
+
+  b.bind(0)
+  await a.send(Buffer.from('hello'), b.address().port)
+})
+
+test('try send without bind', async function (t) {
+  t.plan(1)
+
+  const u = new UDX()
+
+  const a = u.createSocket()
+  const b = u.createSocket()
+
+  b.on('message', function (message) {
+    console.log('recv')
+    t.alike(message, Buffer.from('hello'))
+    a.close()
+    b.close()
+  })
+
+  b.bind(0)
+  a.trySend(Buffer.from('hello'), b.address().port)
+})
+
+test('get address without bind', async function (t) {
+  const u = new UDX()
+  const a = u.createSocket()
+  t.is(a.address(), null)
+})
+
+test('bind twice', async function (t) {
+  t.plan(1)
+
+  const u = new UDX()
+  const a = u.createSocket()
+
+  a.bind(0)
+
+  try {
+    a.bind(0)
+  } catch (error) {
+    t.is(error.message, 'Already bound')
+  }
+
+  await a.close()
+})
+
+test('bind while closing', async function (t) {
+  t.plan(1)
+
+  const u = new UDX()
+  const a = u.createSocket()
+
+  a.close()
+
+  try {
+    a.bind(0)
+  } catch (error) {
+    t.is(error.message, 'Socket is closed')
+  }
+})
+
+test('close twice', async function (t) {
+  t.plan(1)
+
+  const u = new UDX()
+  const a = u.createSocket()
+
+  a.bind(0)
+
+  const closing1 = a.close()
+  const closing2 = a.close()
+
+  t.ok(closing1 === closing2)
+})
+
 test('set TTL', async function (t) {
   t.plan(2)
 

--- a/test/socket.js
+++ b/test/socket.js
@@ -1,5 +1,6 @@
 const test = require('brittle')
 const UDX = require('../')
+const UDXSocket = require('../lib/socket')
 
 test('can bind and close', async function (t) {
   const u = new UDX()
@@ -310,4 +311,143 @@ test('try send after close', async function (t) {
   a.close()
 
   t.is(a.trySend(Buffer.from('hello'), a.address().port), undefined)
+})
+
+test('connect to invalid host ip', async function (t) {
+  t.plan(1)
+
+  const u = new UDX()
+
+  const a = u.createSocket()
+  const s = u.createStream(1)
+
+  const invalidHost = '0.-1.0.0'
+
+  try {
+    s.connect(a, 2, 0, invalidHost)
+    t.fail('Should have given error')
+  } catch (error) {
+    t.is(error.message, `${invalidHost} is not a valid IP address`)
+  }
+})
+
+test('set TTL', async function (t) {
+  t.plan(2)
+
+  const u = new UDX()
+  const a = u.createSocket()
+
+  a.on('message', function (message) {
+    t.alike(message, Buffer.from('hello'))
+    a.close()
+  })
+
+  try {
+    a.setTTL(5)
+  } catch (error) {
+    t.is(error.message, 'Socket not active')
+  }
+
+  a.bind(0)
+  a.setTTL(5)
+
+  await a.send(Buffer.from('hello'), a.address().port)
+})
+
+test('get recv buffer size', async function (t) {
+  t.plan(2)
+
+  const u = new UDX()
+  const a = u.createSocket()
+
+  try {
+    a.getRecvBufferSize()
+  } catch (error) {
+    t.is(error.message, 'Socket not active')
+  }
+
+  a.bind(0)
+  t.ok(a.getRecvBufferSize() > 0)
+
+  await a.close()
+})
+
+test('set recv buffer size', async function (t) {
+  t.plan(2)
+
+  const u = new UDX()
+  const a = u.createSocket()
+
+  const NEW_BUFFER_SIZE = 8192
+
+  try {
+    a.setRecvBufferSize(NEW_BUFFER_SIZE)
+  } catch (error) {
+    t.is(error.message, 'Socket not active')
+  }
+
+  a.bind(0)
+  a.setRecvBufferSize(NEW_BUFFER_SIZE)
+
+  t.is(a.getRecvBufferSize(), NEW_BUFFER_SIZE * 2) // Why recv buffer is double?
+
+  await a.close()
+})
+
+test('get send buffer size', async function (t) {
+  t.plan(2)
+
+  const u = new UDX()
+  const a = u.createSocket()
+
+  try {
+    a.getSendBufferSize()
+  } catch (error) {
+    t.is(error.message, 'Socket not active')
+  }
+
+  a.bind(0)
+  t.ok(a.getSendBufferSize() > 0)
+
+  await a.close()
+})
+
+test('set send buffer size', async function (t) {
+  t.plan(2)
+
+  const u = new UDX()
+  const a = u.createSocket()
+
+  const NEW_BUFFER_SIZE = 8192
+
+  try {
+    a.setSendBufferSize(NEW_BUFFER_SIZE)
+  } catch (error) {
+    t.is(error.message, 'Socket not active')
+  }
+
+  a.bind(0)
+  a.setSendBufferSize(NEW_BUFFER_SIZE)
+
+  t.is(a.getSendBufferSize(), NEW_BUFFER_SIZE * 2) // Why send buffer is double?
+
+  await a.close()
+})
+
+test('UDXSocket - isIPv4', async function (t) {
+  t.is(UDXSocket.isIPv4('127.0.0.1'), true)
+  t.is(UDXSocket.isIPv4('::1'), false)
+  t.is(UDXSocket.isIPv4('0.-1.0.0'), false)
+})
+
+test('UDXSocket - isIPv6', async function (t) {
+  t.is(UDXSocket.isIPv6('127.0.0.1'), false)
+  t.is(UDXSocket.isIPv6('::1'), true)
+  t.is(UDXSocket.isIPv6('0.-1.0.0'), false)
+})
+
+test('UDXSocket - isIP', async function (t) {
+  t.is(UDXSocket.isIP('127.0.0.1'), 4)
+  t.is(UDXSocket.isIP('::1'), 6)
+  t.is(UDXSocket.isIP('0.-1.0.0'), 0)
 })

--- a/test/socket.js
+++ b/test/socket.js
@@ -328,9 +328,6 @@ test('connect to invalid host ip', function (t) {
   } catch (error) {
     t.is(error.message, `${invalidHost} is not a valid IP address`)
   }
-
-  s.destroy()
-  a.close()
 })
 
 test('bind to invalid host ip', function (t) {
@@ -346,8 +343,6 @@ test('bind to invalid host ip', function (t) {
   } catch (error) {
     t.is(error.message, `${invalidHost} is not a valid IP address`)
   }
-
-  a.close()
 })
 
 test('send to invalid host ip', async function (t) {
@@ -427,10 +422,7 @@ test('try send without bind', async function (t) {
 test('get address without bind', async function (t) {
   const u = new UDX()
   const a = u.createSocket()
-
   t.is(a.address(), null)
-
-  a.close()
 })
 
 test('bind twice', async function (t) {

--- a/test/socket.js
+++ b/test/socket.js
@@ -392,7 +392,6 @@ test('send without bind', async function (t) {
   const b = u.createSocket()
 
   b.on('message', function (message) {
-    console.log('recv')
     t.alike(message, Buffer.from('hello'))
     a.close()
     b.close()
@@ -411,7 +410,6 @@ test('try send without bind', async function (t) {
   const b = u.createSocket()
 
   b.on('message', function (message) {
-    console.log('recv')
     t.alike(message, Buffer.from('hello'))
     a.close()
     b.close()

--- a/test/socket.js
+++ b/test/socket.js
@@ -531,7 +531,7 @@ test('set recv buffer size', async function (t) {
   a.bind(0)
   a.setRecvBufferSize(NEW_BUFFER_SIZE)
 
-  t.is(a.getRecvBufferSize(), NEW_BUFFER_SIZE * 2) // Why recv buffer is double?
+  t.is(a.getRecvBufferSize(), NEW_BUFFER_SIZE)
 
   await a.close()
 })
@@ -571,7 +571,7 @@ test('set send buffer size', async function (t) {
   a.bind(0)
   a.setSendBufferSize(NEW_BUFFER_SIZE)
 
-  t.is(a.getSendBufferSize(), NEW_BUFFER_SIZE * 2) // Why send buffer is double?
+  t.is(a.getSendBufferSize(), NEW_BUFFER_SIZE)
 
   await a.close()
 })


### PR DESCRIPTION
For example, I set a new recv buffer size, so I get the recv buffer size and the size returned is double the one I set. Same happens with the send buffer size.

The tests are passing because at the moment of comparison I multiplied by two the new buffer size, but that's obviously not good.

Also, how do I know that the TTL change is actually working? Or is that enough?