### PR TITLE
Automatically translate IPv4 addresses for dualstack sockets

### DIFF
--- a/include/udx.h
+++ b/include/udx.h
@@ -128,6 +128,7 @@ struct udx_socket {
   udx_t *udx;
   udx_cirbuf_t *streams_by_id; // for convenience
 
+  int family;
   int status;
   int readers;
   int events;

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -124,7 +124,7 @@ module.exports = class UDXSocket extends events.EventEmitter {
     if (this.closing) throw new Error('Socket is closed')
 
     if (!port) port = 0
-    if (!host) host = '0.0.0.0'
+    if (!host) host = '::'
 
     const family = ip.isIP(host)
     if (!family) throw new Error(`${host} is not a valid IP address`)

--- a/src/udx.c
+++ b/src/udx.c
@@ -841,6 +841,7 @@ addr_to_v4 (struct sockaddr_in6 *addr) {
   in.sin_len = sizeof(struct sockaddr_in);
 #endif
 
+  // Copy the IPv4 address from the last 4 bytes of the IPv6 address.
   memcpy(&(in.sin_addr), &(addr->sin6_addr.s6_addr[12]), 4);
 
   memcpy(addr, &in, sizeof(in));
@@ -860,6 +861,7 @@ addr_to_v6 (struct sockaddr_in *addr) {
   in.sin6_addr.s6_addr[10] = 0xff;
   in.sin6_addr.s6_addr[11] = 0xff;
 
+  // Copy the IPv4 address to the last 4 bytes of the IPv6 address.
   memcpy(&(in.sin6_addr.s6_addr[12]), &(addr->sin_addr), 4);
 
   memcpy(addr, &in, sizeof(in));

--- a/src/udx.c
+++ b/src/udx.c
@@ -1412,6 +1412,11 @@ udx_stream_connect (udx_stream_t *handle, udx_socket_t *socket, uint32_t remote_
 
   memcpy(&(handle->remote_addr), remote_addr, handle->remote_addr_len);
 
+  if (socket->family == 6 && handle->remote_addr.ss_family == AF_INET) {
+    addr_to_v6((struct sockaddr_in *) &(handle->remote_addr));
+    handle->remote_addr_len = sizeof(struct sockaddr_in6);
+  }
+
   return update_poll(handle->socket);
 }
 

--- a/src/udx.c
+++ b/src/udx.c
@@ -788,7 +788,8 @@ process_packet (udx_socket_t *socket, char *buf, ssize_t buf_len, struct sockadd
 
 static void
 remove_next (udx_fifo_t *f) {
-  while (f->len > 0 && udx__fifo_shift(f) == NULL);
+  while (f->len > 0 && udx__fifo_shift(f) == NULL)
+    ;
 }
 
 static void

--- a/src/udx.c
+++ b/src/udx.c
@@ -832,31 +832,37 @@ is_addr_v4_mapped (const struct sockaddr *addr) {
 
 static inline void
 addr_to_v4 (struct sockaddr_in6 *addr) {
-  struct sockaddr_in *in = (struct sockaddr_in *) addr;
-  in->sin_family = AF_INET;
-  in->sin_port = addr->sin6_port;
+  struct sockaddr_in in;
+  memset(&in, 0, sizeof(in));
+
+  in.sin_family = AF_INET;
+  in.sin_port = addr->sin6_port;
 #ifdef SIN6_LEN
-  in->sin_len = sizeof(struct sockaddr_in);
+  in.sin_len = sizeof(struct sockaddr_in);
 #endif
 
-  memcpy(&(in->sin_addr), &(addr->sin6_addr.s6_addr[12]), 4);
+  memcpy(&(in.sin_addr), &(addr->sin6_addr.s6_addr[12]), 4);
+
+  memcpy(addr, &in, sizeof(in));
 }
 
 static inline void
 addr_to_v6 (struct sockaddr_in *addr) {
-  struct sockaddr_in6 *in = (struct sockaddr_in6 *) addr;
-  in->sin6_family = AF_INET6;
-  in->sin6_port = addr->sin_port;
+  struct sockaddr_in6 in;
+  memset(&in, 0, sizeof(in));
+
+  in.sin6_family = AF_INET6;
+  in.sin6_port = addr->sin_port;
 #ifdef SIN6_LEN
-  in->sin6_len = sizeof(struct sockaddr_in6);
+  in.sin6_len = sizeof(struct sockaddr_in6);
 #endif
 
-  memset(&(in->sin6_addr), 0, 10);
+  in.sin6_addr.s6_addr[10] = 0xff;
+  in.sin6_addr.s6_addr[11] = 0xff;
 
-  in->sin6_addr.s6_addr[10] = 0xff;
-  in->sin6_addr.s6_addr[11] = 0xff;
+  memcpy(&(in.sin6_addr.s6_addr[12]), &(addr->sin_addr), 4);
 
-  memcpy(&(in->sin6_addr.s6_addr[12]), &(addr->sin_addr), 4);
+  memcpy(addr, &in, sizeof(in));
 }
 
 static void

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,6 +3,7 @@ list(APPEND tests
   lookup-invalid
   lookup-ipv6
   socket-send-recv
+  socket-send-recv-dualstack
   socket-send-recv-ipv6
   stream-destroy
   stream-destroy-before-connect

--- a/test/socket-send-recv-dualstack.c
+++ b/test/socket-send-recv-dualstack.c
@@ -1,0 +1,75 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include "../include/udx.h"
+
+uv_loop_t loop;
+udx_t udx;
+
+udx_socket_t asock;
+udx_socket_t bsock;
+
+udx_socket_send_t req;
+
+bool send_called = false;
+bool recv_called = false;
+
+void
+on_send (udx_socket_send_t *r, int status) {
+  assert(&req == r);
+  assert(status == 0);
+
+  send_called = true;
+}
+
+void
+on_recv (udx_socket_t *handle, ssize_t read_len, const uv_buf_t *buf, const struct sockaddr *from) {
+  assert(buf->len == 5);
+  assert(buf->len == read_len);
+  assert(memcmp(buf->base, "hello", 5) == 0);
+
+  uv_stop(&loop);
+
+  recv_called = true;
+}
+
+int
+main () {
+  int e;
+
+  uv_loop_init(&loop);
+
+  e = udx_init(&loop, &udx);
+  assert(e == 0);
+
+  e = udx_socket_init(&udx, &asock);
+  assert(e == 0);
+
+  e = udx_socket_init(&udx, &bsock);
+  assert(e == 0);
+
+  struct sockaddr_in baddr;
+  uv_ip4_addr("127.0.0.1", 8082, &baddr);
+  e = udx_socket_bind(&bsock, (struct sockaddr *) &baddr);
+  assert(e == 0);
+
+  struct sockaddr_in6 aaddr;
+  uv_ip6_addr("::", 8081, &aaddr);
+  e = udx_socket_bind(&asock, (struct sockaddr *) &aaddr);
+  assert(e == 0);
+
+  udx_socket_recv_start(&asock, on_recv);
+
+  struct sockaddr_in aaddr4;
+  uv_ip4_addr("127.0.0.1", 8081, &aaddr4);
+
+  uv_buf_t buf = uv_buf_init("hello", 5);
+  udx_socket_send(&req, &bsock, &buf, 1, (struct sockaddr *) &aaddr4, on_send);
+
+  uv_run(&loop, UV_RUN_DEFAULT);
+
+  assert(send_called && recv_called);
+
+  return 0;
+}

--- a/test/socket.js
+++ b/test/socket.js
@@ -219,8 +219,8 @@ test('can bind to ipv6 and receive from ipv4', async function (t) {
 
   a.on('message', async function (message, { host, family, port }) {
     t.alike(message, Buffer.from('hello'))
-    t.is(host, '::ffff:127.0.0.1')
-    t.is(family, 6)
+    t.is(host, '127.0.0.1')
+    t.is(family, 4)
     t.is(port, b.address().port)
     a.close()
     b.close()
@@ -252,7 +252,7 @@ test('can bind to ipv6 and send to ipv4', async function (t) {
   a.bind(0, '::')
   b.bind(0)
 
-  a.send(Buffer.from('hello'), b.address().port, '::ffff:127.0.0.1')
+  a.send(Buffer.from('hello'), b.address().port, '127.0.0.1')
 })
 
 test('send after close', async function (t) {

--- a/test/socket.js
+++ b/test/socket.js
@@ -209,7 +209,7 @@ test('open + close a bunch of sockets', async function (t) {
   await p
 })
 
-test('can bind to ipv6 and receive ipv4', async function (t) {
+test('can bind to ipv6 and receive from ipv4', async function (t) {
   t.plan(4)
 
   const u = new UDX()
@@ -230,6 +230,29 @@ test('can bind to ipv6 and receive ipv4', async function (t) {
   b.bind(0)
 
   b.send(Buffer.from('hello'), a.address().port, '127.0.0.1')
+})
+
+test('can bind to ipv6 and send to ipv4', async function (t) {
+  t.plan(4)
+
+  const u = new UDX()
+
+  const a = u.createSocket()
+  const b = u.createSocket()
+
+  b.on('message', async function (message, { host, family, port }) {
+    t.alike(message, Buffer.from('hello'))
+    t.is(host, '127.0.0.1')
+    t.is(family, 4)
+    t.is(port, a.address().port)
+    a.close()
+    b.close()
+  })
+
+  a.bind(0, '::')
+  b.bind(0)
+
+  a.send(Buffer.from('hello'), b.address().port, '::ffff:127.0.0.1')
 })
 
 test('send after close', async function (t) {

--- a/test/socket.js
+++ b/test/socket.js
@@ -209,6 +209,29 @@ test('open + close a bunch of sockets', async function (t) {
   await p
 })
 
+test('can bind to ipv6 and receive ipv4', async function (t) {
+  t.plan(4)
+
+  const u = new UDX()
+
+  const a = u.createSocket()
+  const b = u.createSocket()
+
+  a.on('message', async function (message, { host, family, port }) {
+    t.alike(message, Buffer.from('hello'))
+    t.is(host, '::ffff:127.0.0.1')
+    t.is(family, 6)
+    t.is(port, b.address().port)
+    a.close()
+    b.close()
+  })
+
+  a.bind(0, '::')
+  b.bind(0)
+
+  b.send(Buffer.from('hello'), a.address().port, '127.0.0.1')
+})
+
 test('send after close', async function (t) {
   const u = new UDX()
 

--- a/test/stream.js
+++ b/test/stream.js
@@ -715,8 +715,8 @@ test('localHost, localFamily and localPort', async function (t) {
   t.is(stream.localPort, 0)
 
   stream.on('connect', function () {
-    t.is(stream.localHost, '0.0.0.0')
-    t.is(stream.localFamily, 4)
+    t.is(stream.localHost, '::')
+    t.is(stream.localFamily, 6)
     t.is(typeof stream.localPort, 'number')
 
     stream.destroy()


### PR DESCRIPTION
When sending to an IPv4 address from a dualstack IPv6 socket, the address is automatically mapped to an IPv6 address. Likewise, when receiving from an IPv4 address on a dualstack IPv6 socket, the address is automatically translated from a mapped IPv6 address to an IPv4 address.