### PR TITLE
Fix read buffer underflow in framed mode

### DIFF
--- a/binding.c
+++ b/binding.c
@@ -6,6 +6,8 @@
 
 #include "include/udx.h"
 
+#define UDX_MIN_BUF 2 * UDX_DEFAULT_MTU
+
 #define UDX_NAPI_THROW(err) \
   { \
     napi_throw_error(env, uv_err_name(err), uv_strerror(err)); \
@@ -186,7 +188,7 @@ on_udx_stream_read (udx_stream_t *stream, ssize_t read_len, const uv_buf_t *buf)
   n->read_buf_head += buf->len;
   n->read_buf_free -= buf->len;
 
-  if (n->mode == UDX_NAPI_NON_INTERACTIVE && n->read_buf_free >= 2 * UDX_DEFAULT_MTU) {
+  if (n->mode == UDX_NAPI_NON_INTERACTIVE && n->read_buf_free >= 2 * UDX_MIN_BUF) {
     return;
   }
 
@@ -195,7 +197,7 @@ on_udx_stream_read (udx_stream_t *stream, ssize_t read_len, const uv_buf_t *buf)
   if (n->mode == UDX_NAPI_FRAMED) {
     if (n->frame_len <= read) {
       n->frame_len = -1;
-    } else if (n->read_buf_free < 2 * UDX_DEFAULT_MTU) {
+    } else if (n->read_buf_free < 2 * UDX_MIN_BUF) {
       n->frame_len -= read;
     } else {
       return; // wait for more data

--- a/binding.c
+++ b/binding.c
@@ -188,7 +188,7 @@ on_udx_stream_read (udx_stream_t *stream, ssize_t read_len, const uv_buf_t *buf)
   n->read_buf_head += buf->len;
   n->read_buf_free -= buf->len;
 
-  if (n->mode == UDX_NAPI_NON_INTERACTIVE && n->read_buf_free >= 2 * UDX_MIN_BUF) {
+  if (n->mode == UDX_NAPI_NON_INTERACTIVE && n->read_buf_free >= UDX_MIN_BUF) {
     return;
   }
 
@@ -197,7 +197,7 @@ on_udx_stream_read (udx_stream_t *stream, ssize_t read_len, const uv_buf_t *buf)
   if (n->mode == UDX_NAPI_FRAMED) {
     if (n->frame_len <= read) {
       n->frame_len = -1;
-    } else if (n->read_buf_free < 2 * UDX_MIN_BUF) {
+    } else if (n->read_buf_free < UDX_MIN_BUF) {
       n->frame_len -= read;
     } else {
       return; // wait for more data

--- a/test/stream-framed.js
+++ b/test/stream-framed.js
@@ -16,3 +16,28 @@ test('framed mode', function (t) {
   a.write(Buffer.of(0x2, 0x0, 0x0))
   a.write(Buffer.of(0x4, 0x5))
 })
+
+test('framed mode, large message', function (t) {
+  t.plan(1)
+
+  const [a, b] = makeTwoStreams(t, { framed: true })
+
+  const buf = Buffer.alloc(3 + 1024 * 4096 /* 4 MiB */)
+
+  buf[2] = 0x40
+
+  const recv = []
+
+  b
+    .on('data', (buffer) => {
+      recv.push(buffer)
+    })
+    .on('end', () => {
+      t.alike(Buffer.concat(recv), buf)
+
+      a.destroy()
+      b.destroy()
+    })
+
+  a.end(buf)
+})

--- a/test/stream-framed.js
+++ b/test/stream-framed.js
@@ -1,4 +1,5 @@
 const test = require('brittle')
+const b4a = require('b4a')
 const { makeTwoStreams } = require('./helpers')
 
 test('framed mode', function (t) {
@@ -22,7 +23,7 @@ test('framed mode, large message', function (t) {
 
   const [a, b] = makeTwoStreams(t, { framed: true })
 
-  const buf = Buffer.alloc(3 + 1024 * 4096 /* 4 MiB */)
+  const buf = b4a.alloc(3 + 1024 * 4096 /* 4 MiB */)
 
   buf[2] = 0x40
 
@@ -33,7 +34,7 @@ test('framed mode, large message', function (t) {
       recv.push(buffer)
     })
     .on('end', () => {
-      t.alike(Buffer.concat(recv), buf)
+      t.alike(b4a.concat(recv), buf)
 
       a.destroy()
       b.destroy()


### PR DESCRIPTION
To clarify, the actual read buffer would overflow while the tracked free size would underflow, causing large frames to never be delivered in the best case.