### PR TITLE
Update congestion

### DIFF
--- a/.github/workflows/test-cmake.yml
+++ b/.github/workflows/test-cmake.yml
@@ -18,4 +18,5 @@ jobs:
         submodules: true
     - run: cmake -S . -B build
     - run: cmake --build build
-    - run: ctest --verbose --test-dir build/test
+    - run: ctest --verbose --build-config Debug
+      working-directory: build/test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,8 +85,6 @@ target_link_libraries(
   udx_static
   PUBLIC
     uv
-  PRIVATE
-    m
 )
 
 if (UNIX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,8 @@ target_link_libraries(
   udx_shared
   PUBLIC
     uv
+  PRIVATE
+    m
 )
 
 add_library(udx_static STATIC $<TARGET_OBJECTS:udx>)
@@ -77,6 +79,8 @@ target_link_libraries(
   udx_static
   PUBLIC
     uv_a
+  PRIVATE
+    m
 )
 
 install(TARGETS udx_shared udx_static)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.22)
 
 project(udx C)
 
+if (WIN32)
+  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
+
 add_subdirectory(vendor/libuv EXCLUDE_FROM_ALL)
 
 add_library(udx OBJECT)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(udx C)
 
 if (WIN32)
   set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 endif()
 
 add_subdirectory(vendor/libuv EXCLUDE_FROM_ALL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,10 @@ cmake_minimum_required(VERSION 3.22)
 
 project(udx C)
 
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
 if (WIN32)
   set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
-  set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 endif()
 
 add_subdirectory(vendor/libuv EXCLUDE_FROM_ALL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,9 +63,15 @@ target_link_libraries(
   udx_shared
   PUBLIC
     uv
-  PRIVATE
-    m
 )
+
+if (UNIX)
+  target_link_libraries(
+    udx_shared
+    PRIVATE
+      m
+  )
+endif()
 
 add_library(udx_static STATIC $<TARGET_OBJECTS:udx>)
 
@@ -78,10 +84,18 @@ set_target_properties(
 target_link_libraries(
   udx_static
   PUBLIC
-    uv_a
+    uv
   PRIVATE
     m
 )
+
+if (UNIX)
+  target_link_libraries(
+    udx_static
+    PRIVATE
+      m
+  )
+endif()
 
 install(TARGETS udx_shared udx_static)
 

--- a/include/udx.h
+++ b/include/udx.h
@@ -205,6 +205,7 @@ struct udx_stream {
   // timestamps...
   uint64_t rto_timeout;
 
+  size_t sacks;
   size_t inflight;
   size_t ssthresh;
   size_t cwnd;

--- a/include/udx.h
+++ b/include/udx.h
@@ -5,13 +5,13 @@
 extern "C" {
 #endif
 
+#include <math.h>
 #include <stdbool.h>
 #include <stdint.h>
-#include <math.h>
 #include <uv.h>
 
 // TODO: research the packets sizes a bit more
-#define UDX_MSS 1460 // just used for congestion to avoid too many variables...
+#define UDX_MSS         1460 // just used for congestion to avoid too many variables...
 #define UDX_DEFAULT_MTU 1200
 #define UDX_HEADER_SIZE 20
 

--- a/include/udx.h
+++ b/include/udx.h
@@ -10,6 +10,7 @@ extern "C" {
 #include <uv.h>
 
 // TODO: research the packets sizes a bit more
+#define UDX_MSS 1460 // just used for congestion to avoid too many variables...
 #define UDX_DEFAULT_MTU 1200
 #define UDX_HEADER_SIZE 20
 
@@ -179,18 +180,24 @@ struct udx_stream {
   uint32_t rttvar;
   uint32_t rto;
 
-  uint64_t rto_timeout;
-
   uint32_t pkts_waiting;        // how many packets are added locally but not sent?
   uint32_t pkts_inflight;       // packets inflight to the other peer
   uint32_t pkts_buffered;       // how many (data) packets received but not processed (out of order)?
   uint32_t dup_acks;            // how many duplicate acks received? Used for fast retransmit
+  uint32_t fast_retransmit_seq; // which pkt are we waiting for to be acked in fast retransmit
   uint32_t retransmits_waiting; // how many retransmits are waiting to be sent? if 0, then inflight iteration is faster
+  uint32_t seq_flushed;         // highest seq that has been flushed
+
+  // timestamps...
+  uint64_t cubic_k;
+  uint64_t cubic_t;
+  uint64_t rto_timeout;
 
   size_t inflight;
   size_t ssthresh;
   size_t cwnd;
   size_t rwnd;
+  size_t cubic_w_max;
 
   size_t stats_sacks;
   size_t stats_pkts_sent;

--- a/include/udx.h
+++ b/include/udx.h
@@ -143,6 +143,19 @@ struct udx_socket {
   udx_socket_close_cb on_close;
 };
 
+typedef struct udx_cong {
+  uint32_t K;
+  uint32_t ack_cnt;
+  uint32_t origin_point;
+  uint32_t delay_min;
+  uint32_t cnt;
+  uint64_t last_time;
+  uint64_t start_time;
+  uint32_t last_max_cwnd;
+  uint32_t last_cwnd;
+  uint32_t tcp_cwnd;
+} udx_cong_t;
+
 struct udx_stream {
   uint32_t local_id; // must be first entry, so its compat with the cirbuf
   uint32_t remote_id;
@@ -195,17 +208,15 @@ struct udx_stream {
   size_t inflight;
   size_t ssthresh;
   size_t cwnd;
+  size_t cwnd_cnt;
   size_t rwnd;
-
-  // cubic state
-  uint32_t cubic_delay_min;
-  size_t cubic_last_cwnd;
-  uint64_t cubic_k;
-  uint64_t cubic_t;
 
   size_t stats_sacks;
   size_t stats_pkts_sent;
   size_t stats_fast_rt;
+
+  // congestion state
+  udx_cong_t cong;
 
   udx_cirbuf_t outgoing;
   udx_cirbuf_t incoming;

--- a/include/udx.h
+++ b/include/udx.h
@@ -189,15 +189,18 @@ struct udx_stream {
   uint32_t seq_flushed;         // highest seq that has been flushed
 
   // timestamps...
-  uint64_t cubic_k;
-  uint64_t cubic_t;
   uint64_t rto_timeout;
 
   size_t inflight;
   size_t ssthresh;
   size_t cwnd;
   size_t rwnd;
-  size_t cubic_w_max;
+
+  // cubic state
+  uint32_t cubic_delay_min;
+  size_t cubic_last_cwnd;
+  uint64_t cubic_k;
+  uint64_t cubic_t;
 
   size_t stats_sacks;
   size_t stats_pkts_sent;

--- a/include/udx.h
+++ b/include/udx.h
@@ -151,6 +151,7 @@ struct udx_stream {
   int status;
   int out_of_order;
   int recovery;
+  int deferred_ack;
 
   udx_t *udx;
   udx_socket_t *socket;

--- a/include/udx.h
+++ b/include/udx.h
@@ -7,6 +7,7 @@ extern "C" {
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <math.h>
 #include <uv.h>
 
 // TODO: research the packets sizes a bit more

--- a/include/udx.h
+++ b/include/udx.h
@@ -166,6 +166,9 @@ struct udx_stream {
   int recovery;
   int deferred_ack;
 
+  bool reordering_seen;
+  int retransmitting;
+
   udx_t *udx;
   udx_socket_t *socket;
 
@@ -211,8 +214,6 @@ struct udx_stream {
 
   // timestamps...
   uint64_t rto_timeout;
-
-  bool reordering_seen;
 
   size_t sacks;
   size_t inflight;

--- a/include/udx.h
+++ b/include/udx.h
@@ -194,6 +194,13 @@ struct udx_stream {
   uint32_t rttvar;
   uint32_t rto;
 
+  // rack data...
+  uint32_t rack_rtt_min;
+  uint32_t rack_rtt;
+  uint64_t rack_time_sent;
+  uint32_t rack_next_seq;
+  uint32_t rack_fack;
+
   uint32_t pkts_waiting;        // how many packets are added locally but not sent?
   uint32_t pkts_inflight;       // packets inflight to the other peer
   uint32_t pkts_buffered;       // how many (data) packets received but not processed (out of order)?
@@ -204,6 +211,8 @@ struct udx_stream {
 
   // timestamps...
   uint64_t rto_timeout;
+
+  bool reordering_seen;
 
   size_t sacks;
   size_t inflight;

--- a/include/udx.h
+++ b/include/udx.h
@@ -207,24 +207,20 @@ struct udx_stream {
   uint32_t pkts_waiting;        // how many packets are added locally but not sent?
   uint32_t pkts_inflight;       // packets inflight to the other peer
   uint32_t pkts_buffered;       // how many (data) packets received but not processed (out of order)?
-  uint32_t dup_acks;            // how many duplicate acks received? Used for fast retransmit
-  uint32_t fast_retransmit_seq; // which pkt are we waiting for to be acked in fast retransmit
   uint32_t retransmits_waiting; // how many retransmits are waiting to be sent? if 0, then inflight iteration is faster
   uint32_t seq_flushed;         // highest seq that has been flushed
 
   // timestamps...
   uint64_t rto_timeout;
+  uint64_t rack_timeout;
 
-  size_t sacks;
   size_t inflight;
-  size_t ssthresh;
-  size_t cwnd;
-  size_t cwnd_cnt;
-  size_t rwnd;
 
-  size_t stats_sacks;
-  size_t stats_pkts_sent;
-  size_t stats_fast_rt;
+  uint32_t sacks;
+  uint32_t ssthresh;
+  uint32_t cwnd;
+  uint32_t cwnd_cnt;
+  uint32_t rwnd;
 
   // congestion state
   udx_cong_t cong;

--- a/src/debug.h
+++ b/src/debug.h
@@ -7,6 +7,22 @@
 #define DEBUG 0
 #endif
 
+#ifdef DEBUG_STATS
+#include <uv.h>
+#include "../include/udx.h"
+
+static uint64_t debug_start = 0;
+
+static void
+debug_print_cwnd_stats (udx_stream_t *stream) {
+  if (!debug_start) debug_start = uv_hrtime() / 1000000;
+  printf("%llu %u %u %u\n", (uv_hrtime() / 1000000) - debug_start, stream->cwnd, stream->cwnd_cnt, stream->srtt);
+}
+#else
+static void
+debug_print_cwnd_stats (udx_stream_t *stream) {}
+#endif
+
 #define debug_printf(...) \
   do { \
     if (DEBUG) fprintf(stderr, __VA_ARGS__); \

--- a/src/udx.c
+++ b/src/udx.c
@@ -46,6 +46,7 @@
 #define UDX_CONG_BETA_UNIT 1024
 #define UDX_CONG_BETA_SCALE (8 * (UDX_CONG_BETA_UNIT + UDX_CONG_BETA) / 3 / (UDX_CONG_BETA_UNIT - UDX_CONG_BETA)) // 3B/(2-B) scaled 8
 #define UDX_CONG_CUBE_FACTOR UDX_CONG_C_SCALE / UDX_CONG_C
+#define UDX_CONG_INIT_CWND 10
 #define UDX_CONG_MAX_CWND 65536
 
 #ifdef DEBUG_STATS
@@ -1559,7 +1560,7 @@ udx_stream_init (udx_t *udx, udx_stream_t *handle, uint32_t local_id, udx_stream
   handle->sacks = 0;
   handle->inflight = 0;
   handle->ssthresh = 255;
-  handle->cwnd = 2;
+  handle->cwnd = UDX_CONG_INIT_CWND;
   handle->cwnd_cnt = 0;
   handle->rwnd = 0;
 

--- a/src/udx.c
+++ b/src/udx.c
@@ -49,19 +49,6 @@
 #define UDX_CONG_INIT_CWND   10
 #define UDX_CONG_MAX_CWND    65536
 
-#ifdef DEBUG_STATS
-static uint64_t debug_start = 0;
-
-static void
-debug_print_cwnd_stats (udx_stream_t *stream) {
-  if (!debug_start) debug_start = uv_hrtime() / 1000000;
-  printf("%llu %u %u %u\n", (uv_hrtime() / 1000000) - debug_start, stream->cwnd, stream->cwnd_cnt, stream->srtt);
-}
-#else
-static void
-debug_print_cwnd_stats (udx_stream_t *stream) {}
-#endif
-
 typedef struct {
   uint32_t seq; // must be the first entry, so its compat with the cirbuf
 

--- a/src/udx.c
+++ b/src/udx.c
@@ -586,8 +586,8 @@ send_data_packet (udx_stream_t *stream, udx_packet_t *pkt) {
     pkt->is_retransmit = 0;
     stream->retransmits_waiting--;
     if (pkt->transmits == 1) stream->retransmitting++;
-  } else if (seq_compare(stream->seq_flushed, pkt->seq) < 0) {
-    stream->seq_flushed = pkt->seq;
+  } else if (seq_compare(stream->seq_flushed, pkt->seq) <= 0) {
+    stream->seq_flushed = pkt->seq + 1;
   }
 
   pkt->fifo_gc = udx__fifo_push(&(stream->socket->send_queue), pkt);

--- a/src/udx.c
+++ b/src/udx.c
@@ -40,6 +40,14 @@
 #define UDX_SLOW_RETRANSMIT 1
 #define UDX_FAST_RETRANSMIT 2
 
+#define UDX_CONG_C 400 // C=0.4 (inverse) in scaled 1000
+#define UDX_CONG_C_SCALE 1e12 // ms/s ** 3 * c-scale
+#define UDX_CONG_BETA 731 // b=0.3, BETA = 1-b, scaled 1024
+#define UDX_CONG_BETA_UNIT 1024
+#define UDX_CONG_BETA_SCALE (8 * (UDX_CONG_BETA_UNIT + UDX_CONG_BETA) / 3 / (UDX_CONG_BETA_UNIT - UDX_CONG_BETA)) // 3B/(2-B) scaled 8
+#define UDX_CONG_CUBE_FACTOR UDX_CONG_C_SCALE / UDX_CONG_C
+#define UDX_CONG_MAX_CWND 65536
+
 typedef struct {
   uint32_t seq; // must be the first entry, so its compat with the cirbuf
 
@@ -56,6 +64,11 @@ get_microseconds () {
 static uint64_t
 get_milliseconds () {
   return get_microseconds() / 1000;
+}
+
+static inline uint32_t
+cubic_root (uint64_t a) {
+  return (uint32_t) cbrt(a);
 }
 
 static uint32_t
@@ -245,6 +258,123 @@ update_poll (udx_socket_t *socket) {
 
   socket->events = events;
   return uv_poll_start(&(socket->io_poll), events, on_uv_poll);
+}
+
+// cubic congestion as per the paper https://www.cs.princeton.edu/courses/archive/fall16/cos561/papers/Cubic08.pdf
+
+static void
+increase_cwnd (udx_stream_t *stream, uint32_t cnt, uint32_t acked) {
+  // smooth out applying the window increase using the counters...
+
+  if (stream->cwnd_cnt >= cnt) {
+    stream->cwnd_cnt = 0;
+    stream->cwnd++;
+  }
+
+  stream->cwnd_cnt += acked;
+
+  if (stream->cwnd_cnt >= cnt) {
+    uint32_t delta = stream->cwnd_cnt / cnt;
+    stream->cwnd_cnt -= delta * cnt;
+    stream->cwnd += delta;
+  }
+
+  // clamp it
+  if (stream->cwnd > UDX_CONG_MAX_CWND) {
+    stream->cwnd = UDX_CONG_MAX_CWND;
+  }
+}
+
+static void
+reduce_cwnd (udx_stream_t *stream, int reset) {
+  udx_cong_t *c = &(stream->cong);
+
+  if (reset) {
+    memset(c, 0, sizeof(udx_cong_t));
+  } else {
+    c->start_time = 0;
+    c->last_max_cwnd = stream->cwnd < c->last_max_cwnd
+      ? (stream->cwnd * (UDX_CONG_BETA_UNIT + UDX_CONG_BETA)) / (2 * UDX_CONG_BETA_UNIT)
+      : stream->cwnd
+    ;
+  }
+
+  uint32_t upd = (stream->cwnd * UDX_CONG_BETA) / UDX_CONG_BETA_UNIT;
+
+  stream->cwnd = stream->ssthresh = upd < 2 ? 2 : upd;
+  stream->cwnd_cnt = 0; // TODO: dbl check that we should reset this
+}
+
+static void
+update_congestion (udx_cong_t *c, uint32_t cwnd, uint32_t acked, uint64_t time) {
+  c->ack_cnt += acked;
+
+  // sanity check that didn't just enter this
+  if (c->last_cwnd == cwnd && (time - c->last_time) <= 3) return;
+
+  // make sure we don't over run this
+  if (c->start_time && time == c->last_time) goto tcp_friendly;
+
+  c->last_cwnd = cwnd;
+  c->last_time = time;
+
+  // we just entered this, init all state
+  if (c->start_time == 0) {
+    c->start_time = time;
+    c->ack_cnt = acked;
+    c->tcp_cwnd = cwnd;
+
+    if (c->last_max_cwnd <= cwnd) {
+      c->K = 0;
+      c->origin_point = cwnd;
+    } else {
+      c->K = cubic_root(UDX_CONG_CUBE_FACTOR * (c->last_max_cwnd - cwnd));
+      c->origin_point = c->last_max_cwnd;
+    }
+  }
+
+  // time since epoch + delay
+  uint32_t t = time - c->start_time + c->delay_min;
+
+  // |t- K|
+  uint64_t d = (t < c->K) ? (c->K - t) : (t - c->K);
+
+  // C * (t - K)^3
+  uint64_t delta = UDX_CONG_C * d * d * d / UDX_CONG_C_SCALE;
+
+  uint32_t target = t < c->K
+    ? c->origin_point - delta
+    : c->origin_point + delta
+  ;
+
+  // the higher cnt, the slower it applies...
+  c->cnt = target > cwnd
+    ? cwnd / (target - cwnd)
+    : 100 * cwnd; // ie very slowly
+  ;
+
+  // when we have no estimate of current bw make sure to not be too conservative
+  if (c->last_cwnd == 0 && c->cnt > 20) {
+    c->cnt = 20;
+  }
+
+tcp_friendly:
+
+  delta = (UDX_CONG_BETA_SCALE * cwnd) >> 3;
+
+  while (c->ack_cnt > delta) {
+    c->ack_cnt -= delta;
+    c->tcp_cwnd++;
+  }
+
+  if (c->tcp_cwnd > cwnd) {
+    delta = c->tcp_cwnd - cwnd;
+    uint32_t max_cnt = cwnd / delta;
+    if (c->cnt > max_cnt) c->cnt = max_cnt;
+  }
+
+  // one update per 2 acks...
+  if (c->cnt < 2) c->cnt = 2;
 }
 
 static void
@@ -535,53 +665,37 @@ close_maybe (udx_stream_t *stream, int err) {
 }
 
 static void
-increase_cwnd (udx_stream_t *stream, uint64_t time) {
-  if (stream->cwnd < stream->ssthresh) { // If slowstart, grow exponential
-    stream->cwnd++;
+ack_update (udx_stream_t *stream, uint32_t acked, bool is_limited) {
+  uint64_t time = get_milliseconds();
+
+  // if anything acked, reset dups
+  stream->dup_acks = 0;
+  // also reset rto, since things are moving forward...
+  stream->rto_timeout = time + stream->rto;
+
+  udx_cong_t *c = &(stream->cong);
+
+  // If we are application limited, just reset the epic and return...
+  if (is_limited) {
+    c->start_time = 0;
     return;
   }
 
-  size_t cwnd = stream->cwnd;
-
-  if (stream->cubic_delay_min == 0 || stream->srtt < stream->cubic_delay_min) {
-    stream->cubic_delay_min = stream->srtt;
+  if (c->delay_min == 0 || c->delay_min > stream->srtt) {
+    c->delay_min = stream->srtt;
   }
 
-  // We are not in congestion avoidance! Did we just enter? If so clock it.
-  if (stream->cubic_t == 0) {
-    stream->cubic_t = time;
-    // If this is after a timeout (w_max == 0), clock w_max to cwnd per spec. k is set to 0 already.
-    if (stream->cubic_last_cwnd == 0) stream->cubic_last_cwnd = cwnd;
-  }
-
-  uint64_t t = time - stream->cubic_t;
-  uint64_t d = t < stream->cubic_k ? stream->cubic_k - t : t - stream->cubic_k;
-
-  // W_est(t) = W_max*beta_cubic + [3*(1-beta_cubic)/(1+beta_cubic)] * (t/RTT) (Eq. 4)
-  // W_est(t) = W_max*0.7 + [3*(1-0.7)/(1+0.7)] * (t/RTT)
-  // W_est(t) = (7 * W_max + 90 / 17 * (t/RTT)) / 10
-  size_t w_est = (7 * stream->cubic_last_cwnd + t * 90 / stream->srtt / 17) / 10;
-
-  // W_cubic(t) = C*(t-K)^3 + W_max (Eq. 1)
-  // W_cubic(t) = 0.4*(t-K)^3 + W_max
-  // W_cubic(t) = 4*(t-K)^3/10 + W_max
-  size_t w_cubic = 4 * d * d * d / 10000000000 + stream->cubic_last_cwnd;
-
-  if (w_cubic < w_est) {
-    cwnd = w_est < 2 ? 2 : w_est;
+  if (stream->cwnd < stream->ssthresh) {
+    stream->cwnd += acked;
+    if (stream->cwnd > stream->ssthresh) stream->cwnd = stream->ssthresh;
   } else {
-    d += stream->cubic_delay_min;
-    w_cubic = 4 * d * d * d / 10000000000 + stream->cubic_last_cwnd;
-    if (w_cubic > cwnd) cwnd += ((w_cubic - cwnd) / cwnd);
-  }
-
-  if (cwnd > stream->cwnd) {
-    stream->cwnd++;
+    update_congestion(c, stream->cwnd, acked, time);
+    increase_cwnd(stream, c->cnt, acked);
   }
 }
 
 static int
-ack_packet (udx_stream_t *stream, uint32_t seq, int sack, int grow_cwnd) {
+ack_packet (udx_stream_t *stream, uint32_t seq, int sack) {
   udx_cirbuf_t *out = &(stream->outgoing);
   udx_packet_t *pkt = (udx_packet_t *) udx__cirbuf_remove(out, seq);
 
@@ -617,13 +731,6 @@ ack_packet (udx_stream_t *stream, uint32_t seq, int sack, int grow_cwnd) {
 
     // RTO <- SRTT + max (G, K*RTTVAR) where K is 4 maxed with 1s
     stream->rto = max_uint32(stream->srtt + max_uint32(UDX_CLOCK_GRANULARITY_MS, 4 * stream->rttvar), 1000);
-
-    // Congestion control... If we are at the tip of cwnd, grow the window, otherwise reset timer.
-    if (grow_cwnd) {
-      increase_cwnd(stream, time);
-    } else {
-      stream->cubic_t = 0;
-    }
   }
 
   // If this packet was queued for sending we need to remove it from the queue.
@@ -655,7 +762,7 @@ ack_packet (udx_stream_t *stream, uint32_t seq, int sack, int grow_cwnd) {
 }
 
 static uint32_t
-process_sacks (udx_stream_t *stream, char *buf, size_t buf_len, int grow_cwnd) {
+process_sacks (udx_stream_t *stream, char *buf, size_t buf_len) {
   uint32_t n = 0;
   uint32_t *sacks = (uint32_t *) buf;
 
@@ -665,7 +772,7 @@ process_sacks (udx_stream_t *stream, char *buf, size_t buf_len, int grow_cwnd) {
     int32_t len = seq_diff(end, start);
 
     for (int32_t j = 0; j < len; j++) {
-      int a = ack_packet(stream, start + j, 1, grow_cwnd);
+      int a = ack_packet(stream, start + j, 1);
       if (a == 2) return 0; // ended
       if (a == 1) {
         n++;
@@ -690,19 +797,10 @@ fast_retransmit (udx_stream_t *stream) {
     // recover until the full window is packa
     stream->recovery = seq_diff(stream->seq_flushed, stream->remote_acked);
 
-    // adjust congestion
-    stream->cubic_last_cwnd = stream->cwnd;
-    stream->ssthresh = max_uint32(7 * stream->cwnd / 10, 2);
-    stream->cwnd = stream->ssthresh;
+    reduce_cwnd(stream, false);
 
-    // K = cubic_root(W_max*(1-beta_cubic)/C) (Eq. 2)
-    // K = cubic_root(W_max*(1-0.7)/0.4)
-    // K = cubic_root(W_max * 3 / 4)
-    stream->cubic_k = (uint64_t) (1000 * cbrt((long double) stream->cubic_last_cwnd * 3 / 4));
-    stream->cubic_t = 0;
-
-    printf("fast recovery: started, recovery=%u inflight=%zu cwnd=%zu (was %zu) acked=%u, seq=%u srtt=%u\n",
-      stream->recovery, stream->inflight, stream->cwnd, stream->cubic_last_cwnd, stream->remote_acked, stream->seq_flushed, stream->srtt);
+    printf("# fast recovery: started, recovery=%u inflight=%zu cwnd=%zu acked=%u, seq=%u srtt=%u\n",
+      stream->recovery, stream->inflight, stream->cwnd, stream->remote_acked, stream->seq_flushed, stream->srtt);
   }
 
   int resent = 0;
@@ -733,7 +831,7 @@ fast_retransmit (udx_stream_t *stream) {
     stream->rto_timeout = get_milliseconds() + stream->rto;
     update_poll(stream->socket);
 
-    printf("fast recovery: resending lost range (%u pkts) cwnd=%zu\n", resent, stream->cwnd);
+    printf("# fast recovery: resending lost range (%u pkts) cwnd=%zu\n", resent, stream->cwnd);
   }
 }
 
@@ -851,9 +949,10 @@ process_packet (udx_socket_t *socket, char *buf, ssize_t buf_len, struct sockadd
   buf_len -= UDX_HEADER_SIZE;
 
   udx_cirbuf_t *inc = &(stream->incoming);
-  int grow_cwnd = stream->inflight + 2 * UDX_MSS >= stream->cwnd * UDX_MSS;
 
-  uint32_t sacked = (type & UDX_HEADER_SACK) ? process_sacks(stream, buf, buf_len, grow_cwnd) : 0;
+  bool is_limited = stream->inflight + 2 * UDX_MSS < stream->cwnd * UDX_MSS;
+
+  uint32_t sacked = (type & UDX_HEADER_SACK) ? process_sacks(stream, buf, buf_len) : 0;
 
   // Done with header processing now.
   // For future compat, make sure we are now pointing at the actual data using the data_offset
@@ -912,10 +1011,7 @@ process_packet (udx_socket_t *socket, char *buf, ssize_t buf_len, struct sockadd
   int32_t len = seq_diff(ack, stream->remote_acked);
 
   if (len) {
-    // if anything acked, reset dups
-    stream->dup_acks = 0;
-    // also reset rto, since things are moving forward...
-    stream->rto_timeout = get_milliseconds() + stream->rto;
+    ack_update(stream, len, is_limited);
   } else if (sacked > 0 && (stream->recovery == 0 || stream->fast_retransmit_seq < ack) && (stream->recovery || ++(stream->dup_acks) >= 3)) {
     // otherwise if this packed sacked data, it (optionally) a prev fast_retransmit or, and we got 3 dups
     fast_retransmit(stream);
@@ -925,11 +1021,11 @@ process_packet (udx_socket_t *socket, char *buf, ssize_t buf_len, struct sockadd
     if (stream->recovery > 0 && --(stream->recovery) == 0) {
       // The end of fast recovery, adjust according to the spec
       if (stream->ssthresh < stream->cwnd) stream->cwnd = stream->ssthresh;
-      printf("fast recovery: ended, total retransmits %zu / %zu, inflight=%zu, cwnd=%zu, acked=%u, seq=%u\n",
+      printf("# fast recovery: ended, total retransmits %zu / %zu, inflight=%zu, cwnd=%zu, acked=%u, seq=%u\n",
         stream->stats_fast_rt, stream->stats_pkts_sent, stream->inflight, stream->cwnd, stream->remote_acked + 1, stream->seq_flushed);
     }
 
-    int a = ack_packet(stream, stream->remote_acked++, 0, grow_cwnd);
+    int a = ack_packet(stream, stream->remote_acked++, 0);
 
     if (a == 0 || a == 1) continue;
     if (a == 2) { // it ended, so ack that and trigger close
@@ -943,11 +1039,11 @@ process_packet (udx_socket_t *socket, char *buf, ssize_t buf_len, struct sockadd
 
   // if data pkt, send an ack - use deferred acks as well...
   if (type & UDX_HEADER_DATA_OR_END) {
-    if (stream->out_of_order) {
+    // if (stream->out_of_order) {
       send_state_packet(stream);
-    } else if (stream->deferred_ack == 0) {
-      stream->deferred_ack = 1; // lets try with a clock single tick first
-    }
+    // } else if (stream->deferred_ack == 0) {
+      // stream->deferred_ack = 1; // lets try with a clock single tick first
+    // }
   }
 
   if ((stream->status & UDX_STREAM_SHOULD_END_REMOTE) == UDX_STREAM_END_REMOTE && seq_compare(stream->remote_ended, stream->ack) <= 0) {
@@ -1375,15 +1471,10 @@ udx_stream_init (udx_t *udx, udx_stream_t *handle, uint32_t local_id, udx_stream
   handle->seq_flushed = 0;
 
   handle->inflight = 0;
-  handle->ssthresh = 0xff;
+  handle->ssthresh = 255;
   handle->cwnd = 2;
+  handle->cwnd_cnt = 0;
   handle->rwnd = 0;
-
-  // cubic state (congestion)
-  handle->cubic_delay_min = 0;
-  handle->cubic_last_cwnd = 0;
-  handle->cubic_k = 0;
-  handle->cubic_t = 0;
 
   handle->stats_sacks = 0;
   handle->stats_pkts_sent = 0;
@@ -1394,6 +1485,9 @@ udx_stream_init (udx_t *udx, udx_stream_t *handle, uint32_t local_id, udx_stream
   handle->on_recv = NULL;
   handle->on_drain = NULL;
   handle->on_close = close_cb;
+
+  // Clear congestion state
+  memset(&(handle->cong), 0, sizeof(udx_cong_t));
 
   udx__cirbuf_init(&(handle->relaying_streams), 2);
 
@@ -1528,18 +1622,11 @@ udx_stream_check_timeouts (udx_stream_t *handle) {
     // Make sure to clear all new packets that are in the queue
     unqueue_first_transmits(handle);
 
+    // Reduce the congestion window (full reset)
+    reduce_cwnd(handle, true);
+
     // Ensure it backs off until data is acked...
     handle->rto_timeout = now + 2 * handle->rto;
-
-    // Update congestion control
-    handle->ssthresh = max_uint32(7 * handle->cwnd / 10, 2);
-    handle->cwnd = 2;
-
-    // Reset cubic state
-    handle->cubic_delay_min = 0;
-    handle->cubic_last_cwnd = 0;
-    handle->cubic_t = 0;
-    handle->cubic_k = 0;
 
     // Consider all packet losts - seems to be the simple consensus across different stream impls
     // which we like cause it is nice and simple to implement.
@@ -1563,7 +1650,7 @@ udx_stream_check_timeouts (udx_stream_t *handle) {
       handle->retransmits_waiting++;
     }
 
-    printf("timeout! pkt loss detected - ssthresh=%zu cwnd=%zu inflight=%zu acked=%u seq=%u rtt=%i\n",
+    printf("# timeout! pkt loss detected - ssthresh=%zu cwnd=%zu inflight=%zu acked=%u seq=%u rtt=%i\n",
       handle->ssthresh, handle->cwnd, handle->inflight, handle->remote_acked, handle->seq_flushed, handle->srtt);
   }
 

--- a/src/udx.c
+++ b/src/udx.c
@@ -382,7 +382,9 @@ update_congestion (udx_cong_t *c, uint32_t cwnd, uint32_t acked, uint64_t time) 
 
 static void
 unqueue_first_transmits (udx_stream_t *stream) {
-  for (uint32_t seq = stream->seq_flushed; seq != stream->remote_acked; seq--) {
+  if (stream->seq_flushed == stream->remote_acked) return;
+
+  for (uint32_t seq = stream->seq_flushed - 1; seq != stream->remote_acked; seq--) {
     udx_packet_t *pkt = (udx_packet_t *) udx__cirbuf_get(&(stream->outgoing), seq);
 
     if (pkt == NULL || pkt->transmits != 0 || pkt->status != UDX_PACKET_SENDING) break;

--- a/src/udx.c
+++ b/src/udx.c
@@ -48,7 +48,6 @@
 #define UDX_CONG_CUBE_FACTOR UDX_CONG_C_SCALE / UDX_CONG_C
 #define UDX_CONG_MAX_CWND 65536
 
-#define DEBUG_STATS 1
 #ifdef DEBUG_STATS
 static uint64_t debug_start = 0;
 

--- a/src/udx.c
+++ b/src/udx.c
@@ -705,7 +705,7 @@ printf("pre fast rt, inflight=%zu, pkts_inflight=%u ssthresh=%zu, cwnd=%zu acked
     // K = cubic_root(W_max*(1-beta_cubic)/C) (Eq. 2)
     // K = cubic_root(W_max*(1-0.7)/0.4)
     // K = cubic_root(W_max * 3 / 4)
-    stream->cubic_k = (uint64_t) (1000 * cbrt((long double) stream->cubic_w_max * 3 / 4 / UDX_MSS));
+    stream->cubic_k = (uint64_t) (1000 * cbrt((long double) stream->cubic_w_max * 3 / UDX_MSS / 4));
     stream->cubic_t = 0;
 
 printf("entering recovery mode! total recovery length = %u (remote_acked %u, seq_flushed %u, window %u)\n", stream->recovery, stream->remote_acked, stream->seq_flushed, stream->seq_flushed - stream->remote_acked);

--- a/src/udx.c
+++ b/src/udx.c
@@ -1011,7 +1011,7 @@ process_packet (udx_socket_t *socket, char *buf, ssize_t buf_len, struct sockadd
   int32_t len = seq_diff(ack, stream->remote_acked);
 
   if (len) {
-    ack_update(stream, len, is_limited);
+    if (len > 0) ack_update(stream, len, is_limited);
   } else if (sacked > 0 && (stream->recovery == 0 || stream->fast_retransmit_seq < ack) && (stream->recovery || ++(stream->dup_acks) >= 3)) {
     // otherwise if this packed sacked data, it (optionally) a prev fast_retransmit or, and we got 3 dups
     fast_retransmit(stream);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,7 +19,7 @@ list(APPEND tests
 foreach(test IN LISTS tests)
   add_executable(test_${test} ${test}.c)
 
-  target_link_libraries(test_${test} udx_static)
+  target_link_libraries(test_${test} udx_shared)
 
   add_test(${test} test_${test})
 endforeach()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,9 +17,12 @@ list(APPEND tests
 )
 
 foreach(test IN LISTS tests)
-  add_executable(test_${test} ${test}.c)
+  add_executable(${test} ${test}.c)
 
-  target_link_libraries(test_${test} udx_shared)
+  target_link_libraries(${test} udx_shared)
 
-  add_test(${test} test_${test})
+  add_test(
+    NAME ${test} 
+    COMMAND ${test}
+  )
 endforeach()

--- a/test/stream-parallel.js
+++ b/test/stream-parallel.js
@@ -2,6 +2,7 @@ const test = require('brittle')
 const { makePairs, pipeStreamPairs } = require('./helpers')
 
 test('16 parallel streams on 1 socket', function (t) {
+  t.timeout(60000)
   const { streams, close } = makePairs(16, 'single')
   t.teardown(close)
   t.plan(1)
@@ -13,6 +14,7 @@ test('16 parallel streams on 1 socket', function (t) {
 })
 
 test('16 parallel streams on 16 sockets', function (t) {
+  t.timeout(60000)
   const { streams, close } = makePairs(16, 'multi')
   t.teardown(close)
   t.plan(1)


### PR DESCRIPTION
This implements cubic congestion and rack! 

Cubic: https://www.cs.princeton.edu/courses/archive/fall16/cos561/papers/Cubic08.pdf
RACK: https://datatracker.ietf.org/doc/rfc8985/

RACK is used for fast recovery instead of the reno heuristic and seems very very efficient in testing.
Cubic is used for general congestion window upgrade/downgrade.

Both are used by Linux TCP per default, so also very established.
This is still missing RACK-TLP, but I think that should come in another PR to minimise the disruption here.